### PR TITLE
Fix failed spec

### DIFF
--- a/spec/notification_spec.js
+++ b/spec/notification_spec.js
@@ -5,6 +5,7 @@ describe("notification", function() {
         var internal;
         var current_time;
         var message;
+        var author_id;
 
         beforeEach(function() {
             // setup
@@ -28,6 +29,7 @@ describe("notification", function() {
 
             current_time = new Date();
             message = "some message";
+            author_id = 1;
 
             // exercise
             notification.notify({
@@ -35,7 +37,8 @@ describe("notification", function() {
                 project_event: project_event,
                 internal:      internal,
                 current_time:  current_time,
-                message:       message
+                message:       message,
+                author_id:     author_id
             });
         });
 
@@ -63,7 +66,8 @@ describe("notification", function() {
                 project_name: project.name,
                 target_id:    internal.target_id,
                 target_url:   internal.target_url,
-                message:      message
+                message:      message,
+                author_id:    author_id
             };
 
             var actual = config.getNotifiedHistories()[0];


### PR DESCRIPTION
for https://github.com/sue445/chrome-gitlab-notifier/pull/81

``` sh
[sue445@sue445-MBP.local] ✓ ~/workspace/github.com/sue445/chrome-gitlab-notifier (pr/81)
[sue445@sue445-MBP.local] [03-30 01:35:07] $  phantomjs spec/lib/run-jasmine.js spec/SpecRunner.html
MOCK GET: http://example.com/api/v3/projects [object Object]
MOCK GET: http://example.com/api/v3/projects/gitlab%2Fgitlabhq/issues/42 [object Object]
MOCK GET: http://example.com/api/v3/projects/gitlab%2Fgitlabhq/issues/42 [object Object]
'waitFor()' finished in 1709ms.

gitlab
Passing 6 specs

[sue445@sue445-MBP.local] ✓ ~/workspace/github.com/sue445/chrome-gitlab-notifier (pr/81)
[sue445@sue445-MBP.local] [03-30 01:37:26] $
```

spec is successful
